### PR TITLE
Fix incompatibility with RuboCop extensions that modify Include/Exclu…

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -1,3 +1,8 @@
+inherit_mode:
+  merge:
+    - Include
+    - Exclude
+
 Markdown:
   WarnInvalid: true
   Autodetect: true


### PR DESCRIPTION
…de for cops

Consider this example:
* A different extension (like rubocop-erb) gets loaded first and modifies a cops Exclude list
* rubocop-md gets loaded and also modifies the same cops exclude list
* rubocop-md discards the changes from rubocop-erb because the configs aren't being merged